### PR TITLE
Get rid of legacy in-house slo framework

### DIFF
--- a/helm/aws-load-balancer-controller/templates/deployment.yaml
+++ b/helm/aws-load-balancer-controller/templates/deployment.yaml
@@ -9,7 +9,6 @@ metadata:
   {{- end }}
   labels:
     giantswarm.io/service-type: "managed"
-    giantswarm.io/monitoring_basic_sli: "true"
     {{- include "aws-load-balancer-controller.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/31095

Getting rid of the legacy in-house slo framework
